### PR TITLE
[WIP] fix errors and warn with npm

### DIFF
--- a/lib/stacks/native.js
+++ b/lib/stacks/native.js
@@ -24,7 +24,7 @@ const install = async (projectName) => {
         resolve();
       })
       .catch(() => reject(new Error(`Install step: ${installCmd} installation failed`)));
-  });
+  }).catch((error) => output.error(error.message));
 };
 
 const rename = async (projectName, bundleId) => {

--- a/lib/stacks/next.js
+++ b/lib/stacks/next.js
@@ -25,7 +25,7 @@ const install = async (projectName) => {
         resolve();
       })
       .catch(() => reject(new Error(`${installCmd} installation failed`)));
-  });
+  }).catch((error) => output.error(error.message));
 };
 
 async function next(projectName, projectPath, projectStyle) {


### PR DESCRIPTION
When running `npx create-r3f-app next my-app sass` the following DeprecationWarning appeared

```
npm@6.13.4 C:\Program Files\nodejs\node_modules\npm
(node:2764) UnhandledPromiseRejectionWarning: Error: npm installation failed
    at C:\Users\a.baraou\AppData\Roaming\npm-cache\_npx\2764\node_modules\create-r3f-app\lib\stacks\next.js:27:27
    at processTicksAndRejections (internal/process/task_queues.js:94:5)
(node:2764) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:2764) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
The current merge request fix that.

Now the error displayed is `Error! Command failed with exit code 1: npm`

I believed it's caused by this line 
`execa(installCmd, null, { stdio: 'inherit' })`
Running npm without command triggers this error
If I replace it with 
`execa(installCmd, ['-v'], { stdio: 'inherit' })`
everything runs smoothly

Since I'm not sure what's the point of this line and how it behaves when called with yarn, I didn't include this "fix" in the merge request.