### PR TITLE
Added command-exists package in order to fix error message when used with npx on Windows and Linux

### DIFF
--- a/lib/stacks/next.js
+++ b/lib/stacks/next.js
@@ -5,6 +5,7 @@ const sysPath = require('path');
 const chalk = require('chalk');
 const hostedGitInfo = require('hosted-git-info');
 const execa = require('execa');
+const commandExists = require('command-exists');
 
 const initGit = require('../utils/init-git');
 const messages = require('../utils/messages');
@@ -18,7 +19,7 @@ const install = async (projectName) => {
   process.chdir(projectName);
 
   return new Promise((resolve, reject) => {
-    execa(installCmd, null, { stdio: 'inherit' })
+    commandExists(installCmd)
       .then(() => execa(installCmd, ['install']))
       .then(() => {
         output.success(`Installed dependencies for ${output.cmd(projectName)}`);

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "ansi-escapes": "^4.3.1",
     "bluebird": "^3.7.2",
     "chalk": "^4.1.0",
+    "command-exists": "^1.2.9",
     "commander": "^6.1.0",
     "create-react-app": "3.4.1",
     "execa": "^4.0.3",


### PR DESCRIPTION
Hey,

Just dropping an option here in case you find this useful.

When using this package on my Windows or Linux I was getting the following message.

![error-npm](https://user-images.githubusercontent.com/7174039/98416908-4cb89500-2080-11eb-942f-116fed690a3f.PNG)

This is following my previous pull request concerning npm running without parameters  #1 
The following might be a better way to test if a command exist.

https://www.npmjs.com/package/command-exists
https://github.com/mathisonian/command-exists

I just did basic test, not sure this solution is covering all the previous use cases.