### PR TITLE
feat: add TypeScript support

### DIFF
--- a/bin/create-r3f-app
+++ b/bin/create-r3f-app
@@ -13,6 +13,7 @@ let projectName;
 program
   .version(pkg.version)
   .arguments('<app-type> <project-directory> ')
+  .option('-ts, --typescript', 'create r3f app with TypeScript')
   .usage(`${chalk.yellow('<app-type>')} ${chalk.green('<project-directory>')} `)
   .action(function projectNameAction(type, name) {
     appType = type;
@@ -22,7 +23,11 @@ program
   .on('--help', messages.help)
   .parse(process.argv);
 
+const options = program.opts();
+const projectOption = options.typescript ? 'typescript' : 'default';
+
 createR3fApp({
   appType,
   projectName,
+  projectOption,
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ const next = require('./stacks/next');
 // todo add gatsby and native
 const appTypes = ['next'];
 
-module.exports = async function createR3fApp({ projectName, appType }) {
+module.exports = async function createR3fApp({ projectName, appType, projectOption }) {
   console.log(chalk.bold(chalk.blue(`Welcome. Project's generation started using create-R3F-App 🐱`)));
 
   await checkForUpdate();
@@ -52,7 +52,7 @@ module.exports = async function createR3fApp({ projectName, appType }) {
     //   native(projectName, process.argv[4]);
     //   break;
     case 'next':
-      next(projectName, projectPath, appStyle);
+      next(projectName, projectPath, appStyle, projectOption);
       break;
     default:
       break;

--- a/lib/stacks/next.js
+++ b/lib/stacks/next.js
@@ -12,7 +12,7 @@ const messages = require('../utils/messages');
 const getInstallCmd = require('../utils/get-install-cmd');
 const output = require('../utils/output');
 
-const install = async (projectName) => {
+const install = async (projectName, typescript) => {
   const installCmd = getInstallCmd();
 
   output.info('Installing packages...');
@@ -21,15 +21,64 @@ const install = async (projectName) => {
   return new Promise((resolve, reject) => {
     commandExists(installCmd)
       .then(() => execa(installCmd, ['install']))
-      .then(() => {
-        output.success(`Installed dependencies for ${output.cmd(projectName)}`);
+      .then(() => output.success(`Installed dependencies for ${output.cmd(projectName)}`))
+      .then(async () => {
+        if (typescript) {
+          const useYarn = installCmd === 'yarn';
+          output.info('Installing packages for TypeScript...');
+          const installDepsCmd = useYarn ? 'add' : 'install'
+          await execa(installCmd, [installDepsCmd, '-D', 'typescript', '@types/react', '@types/node']);
+          output.success('Installed dependencies for TypeScript');
+        }
         resolve();
       })
       .catch(() => reject(new Error(`${installCmd} installation failed`)));
   }).catch((error) => output.error(error.message));
 };
 
-async function next(projectName, projectPath, projectStyle) {
+const initForTypeScript = async (root) => {
+  output.info('Initializing for TypeScript...');
+
+  const jsConfigJson = await fs.readFile(sysPath.join(root, 'jsconfig.json'))
+    .then((value) => {
+      const lines = value.toString().split('\n');
+      const filtered = lines.filter(line => !line.match(/@js-ignore/));
+      return JSON.parse(filtered.join(''));
+    });
+  const compilerOptions = jsConfigJson.compilerOptions;
+  const { module, ...others } = compilerOptions;
+  const tsConfigBaseJson = {
+    compilerOptions: others
+  };
+  await fs.writeJson(sysPath.join(root, 'tsconfig.json'), tsConfigBaseJson, { spaces: 2 });
+  await fs.remove(sysPath.join(root, 'jsconfig.json'));
+  await fs.remove(sysPath.join(root, 'jsconfig.server.json'));
+
+  const installCmd = getInstallCmd();
+  const useYarn = installCmd === 'yarn';
+  const buildCmd = useYarn ? ['build'] : ['run', 'build'];
+
+  await execa(installCmd, buildCmd);
+  output.success('Succeed to initialize');
+}
+
+const recursiveReaddir = async (root, dir, files = []) => {
+  const srcDirs = [];
+  const srcDirents = await fs.readdir(sysPath.join(root, dir), { withFileTypes: true });
+
+  srcDirents.forEach((dirent) => {
+    if (dirent.isDirectory()) srcDirs.push(`${dir}/${dirent.name}`);
+    if (dirent.isFile()) files.push(`${dir}/${dirent.name}`);
+  });
+
+  for (const srcDir of srcDirs) {
+    files = await recursiveReaddir(root, srcDir, files);
+  }
+
+  return Promise.resolve(files);
+}
+
+async function next(projectName, projectPath, projectStyle, projectOption) {
   output.info(
     `🚀 Creating ${chalk.bold(chalk.green(projectName))} using ${chalk.bold(
       'r3f-next-starter',
@@ -54,10 +103,27 @@ async function next(projectName, projectPath, projectStyle) {
   output.success(`Folder and files created for ${output.cmd(projectName)}`);
 
   await fs.remove(sysPath.join(projectName, '.git'));
-  await install(projectName);
-  process.chdir(projectPath);
-  await initGit('Next');
+  
+  const typescript = projectOption === 'typescript';
+  const root = sysPath.resolve(projectName);
 
+  await install(projectName, typescript);
+  process.chdir(projectPath);
+
+  if (typescript) {
+    await initForTypeScript(root);
+
+    const srcAllFiles = await recursiveReaddir(root, 'src');
+    const srcJsFiles = srcAllFiles.filter(file => new RegExp(/.js|jsx/).test(file));
+
+    for (const srcJsFile of srcJsFiles) {
+      const parsed = sysPath.parse(srcJsFile);
+      const newExt = parsed.ext === '.js' ? '.ts' : '.tsx';
+      await fs.rename(sysPath.join(root, srcJsFile), sysPath.join(root, `${parsed.dir}/${parsed.name}${newExt}`));
+    }
+  }
+
+  await initGit('Next');
   messages.start(projectName, 'next');
 }
 


### PR DESCRIPTION
Related: https://github.com/pmndrs/react-three-next/issues/22

- [x] create `tsconfig.json` file
- [x] `yarn add --dev typescript @types/react @types/node`
- [x] yarn build to generate `tsconfig.json` from next or pick the template from next
- [x] copy the path aliases from `jsconfig.json` to `tsconfig.json`
- [x] move all JS files into TS