### PR TITLE
fix: lint with TypeScript

### DIFF
--- a/lib/stacks/next.js
+++ b/lib/stacks/next.js
@@ -56,7 +56,6 @@ const initForTypeScript = async (root) => {
 
   const packageJson = await fs.readJSON(sysPath.join(root, 'package.json'));
   const { scripts, ...otherConfigs } = packageJson;
-  scripts.eslint = 'eslint --fix \"./src/**/*.{ts,tsx}\"';
   scripts.prettier = 'prettier --list-different \"./src/**/*.{ts,tsx,md}\"';
   const newPackageJson = { ...otherConfigs, scripts };
   await fs.writeJSON(sysPath.join(root, 'package.json'), newPackageJson, { spaces: 2 });

--- a/lib/stacks/next.js
+++ b/lib/stacks/next.js
@@ -46,13 +46,20 @@ const initForTypeScript = async (root) => {
       return JSON.parse(filtered.join(''));
     });
   const compilerOptions = jsConfigJson.compilerOptions;
-  const { module, ...others } = compilerOptions;
+  const { module, ...otherOptions } = compilerOptions;
   const tsConfigBaseJson = {
-    compilerOptions: others
+    compilerOptions: otherOptions
   };
   await fs.writeJson(sysPath.join(root, 'tsconfig.json'), tsConfigBaseJson, { spaces: 2 });
   await fs.remove(sysPath.join(root, 'jsconfig.json'));
   await fs.remove(sysPath.join(root, 'jsconfig.server.json'));
+
+  const packageJson = await fs.readJSON(sysPath.join(root, 'package.json'));
+  const { scripts, ...otherConfigs } = packageJson;
+  scripts.eslint = 'eslint --fix \"./src/**/*.{ts,tsx}\"';
+  scripts.prettier = 'prettier --list-different \"./src/**/*.{ts,tsx,md}\"';
+  const newPackageJson = { ...otherConfigs, scripts };
+  await fs.writeJSON(sysPath.join(root, 'package.json'), newPackageJson, { spaces: 2 });
 
   const installCmd = getInstallCmd();
   const useYarn = installCmd === 'yarn';


### PR DESCRIPTION
Implemented some modifications to the npm script to run eslint and prettier when a project is generated in TypeScript.