### PR TITLE
fix: handle missing directory in tailwind migration

### DIFF
--- a/lib/stacks/next.js
+++ b/lib/stacks/next.js
@@ -74,9 +74,12 @@ const install = async (projectName, typescript, isNotDefaultStyle) => {
 
 const recursiveReaddir = async (root, dir, files = []) => {
   const srcDirs = [];
-  const srcDirents = await fs.readdir(sysPath.join(root, dir), {
+  const pathExists = await fs.stat(sysPath.join(root, dir))
+    .then(stat => stat.isDirectory())
+    .catch(() => false);
+  const srcDirents = pathExists ? await fs.readdir(sysPath.join(root, dir), {
     withFileTypes: true,
-  });
+  }) : [];
 
   srcDirents.forEach((dirent) => {
     if (dirent.isDirectory()) srcDirs.push(`${dir}/${dirent.name}`);


### PR DESCRIPTION
- Resolves "no such file or directory" [issue reported here](https://github.com/pmndrs/react-three-next/issues/119)